### PR TITLE
singularity compatibility, bump version to 0.0.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,6 @@ RUN pip3 install lmdb scikit-image imagecodecs
 #Copy executable
 COPY src ${EXEC_DIR}/
 
-WORKDIR ${EXEC_DIR}
-
 # Default command. Additional arguments are provided through the command line
-ENTRYPOINT ["python3", "inference.py"]
+ENTRYPOINT ["python3", "/opt/executables/inference.py"]
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ docker pull wipp/wipp-unet-cnn-inference-plugin
 ```bash
 #!/bin/bash
 
-version=0.0.7
+version=0.0.8
 docker build . -t wipp/wipp-unet-cnn-inference-plugin:latest
 docker build . -t wipp/wipp-unet-cnn-inference-plugin:${version}
 ```

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -6,6 +6,6 @@
 
 # You are solely responsible for determining the appropriateness of using and distributing the software and you assume all risks associated with its use, including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and the unavailability or interruption of operation. This software is not intended to be used in any situation where a failure could cause risk of injury or damage to property. The software developed by NIST employees is not subject to copyright protection within the United States.
 
-version=0.0.7
+version=0.0.8
 docker build . -t wipp/wipp-unet-cnn-inference-plugin:latest
 docker build . -t wipp/wipp-unet-cnn-inference-plugin:${version}

--- a/plugin.json
+++ b/plugin.json
@@ -1,13 +1,13 @@
 {
   "name": "WIPP UNet CNN Inference Plugin",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "title": "UNet CNN Inference",
   "author": "Michael Majurski",
     "institution": "National Institute of Standards and Technology",
     "repository": "https://github.com/usnistgov/WIPP-unet-inference-plugin",
     "citation": "Ronneberger, Olaf, Philipp Fischer, and Thomas Brox. \"U-net: Convolutional networks for biomedical image segmentation.\" International Conference on Medical image computing and computer-assisted intervention. Springer, Cham, 2015.",
   "description": "Inference with a UNet CNN model",
-  "containerId": "wipp/wipp-unet-cnn-inference-plugin:0.0.7",
+  "containerId": "wipp/wipp-unet-cnn-inference-plugin:0.0.8",
   "inputs": [
     {
       "name": "imageDir",

--- a/push-docker.sh
+++ b/push-docker.sh
@@ -7,6 +7,6 @@
 # You are solely responsible for determining the appropriateness of using and distributing the software and you assume all risks associated with its use, including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and the unavailability or interruption of operation. This software is not intended to be used in any situation where a failure could cause risk of injury or damage to property. The software developed by NIST employees is not subject to copyright protection within the United States.
 
 
-version=0.0.7
+version=0.0.8
 docker push wipp/wipp-unet-cnn-inference-plugin:latest
 docker push wipp/wipp-unet-cnn-inference-plugin:${version}


### PR DESCRIPTION
Changes:

- remove WORKDIR instruction and use absolute path in entrypoint command in Dockerfile for Singularity compatibility
- bump version to 0.0.8